### PR TITLE
update lambda to use nodejs_16_x runtime

### DIFF
--- a/deployment/lib/api/api-gateway-stack.ts
+++ b/deployment/lib/api/api-gateway-stack.ts
@@ -48,7 +48,7 @@ export class ApiGatewayStack extends cdk.Stack {
     // create the lambda function
     const stepUpAuthorizerFunc = new lambda.Function(this, 'step-up-auth-authorizer-lambda', {
       code: lambda.Code.fromBucket(stepUpAuthorizerAsset.bucket, stepUpAuthorizerAsset.s3ObjectKey),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       handler: 'src/index.handler',
       timeout: cdk.Duration.seconds(30),
       memorySize: 512,

--- a/deployment/lib/api/lambda-stack.ts
+++ b/deployment/lib/api/lambda-stack.ts
@@ -35,7 +35,7 @@ export class LambdaStack extends cdk.Stack {
     // create the lambda function
     this.stepUpInitiateFunc = new lambda.Function(this, 'step-up-auth-initiate-lambda', {
       code: lambda.Code.fromBucket(stepUpInitiateAsset.bucket, stepUpInitiateAsset.s3ObjectKey),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       handler: 'src/index.handler',
       timeout: cdk.Duration.seconds(30),
       memorySize: 512,
@@ -56,7 +56,7 @@ export class LambdaStack extends cdk.Stack {
     // create the lambda function
     this.stepUpChallengeFunc = new lambda.Function(this, 'step-up-auth-challenge-lambda', {
       code: lambda.Code.fromBucket(stepUpChallengeAsset.bucket, stepUpChallengeAsset.s3ObjectKey),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       handler: 'src/index.handler',
       timeout: cdk.Duration.seconds(30),
       memorySize: 512,
@@ -79,7 +79,7 @@ export class LambdaStack extends cdk.Stack {
     // create the lambda function
     this.stepUpSampleApiFunc = new lambda.Function(this, 'step-up-auth-sample-api-lambda', {
       code: lambda.Code.fromBucket(stepUpSampleApiAsset.bucket, stepUpSampleApiAsset.s3ObjectKey),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       handler: 'src/index.handler',
       timeout: cdk.Duration.seconds(30),
       memorySize: 512,

--- a/source/sample-api/deploy-awscli.sh
+++ b/source/sample-api/deploy-awscli.sh
@@ -82,7 +82,7 @@ if [ $? -ne 0 ]; then
         --region ${AWS_REGION} \
         --function-name ${module_name} \
         --zip-file fileb://"${module_zip_path}" \
-        --runtime nodejs12.x \
+        --runtime nodejs16.x \
         --tracing-config Mode=PassThrough \
         --timeout 30 \
         --memory-size 128 \

--- a/source/step-up-authorizer/deploy-awscli.sh
+++ b/source/step-up-authorizer/deploy-awscli.sh
@@ -84,7 +84,7 @@ if [ $? -ne 0 ]; then
         --region ${AWS_REGION} \
         --function-name ${module_name} \
         --zip-file fileb://"${module_zip_path}" \
-        --runtime nodejs12.x \
+        --runtime nodejs16.x \
         --tracing-config Mode=PassThrough \
         --timeout 30 \
         --memory-size 128 \

--- a/source/step-up-challenge/deploy-awscli.sh
+++ b/source/step-up-challenge/deploy-awscli.sh
@@ -82,7 +82,7 @@ if [ $? -ne 0 ]; then
         --region ${AWS_REGION} \
         --function-name ${module_name} \
         --zip-file fileb://"${module_zip_path}" \
-        --runtime nodejs12.x \
+        --runtime nodejs16.x \
         --tracing-config Mode=PassThrough \
         --timeout 30 \
         --memory-size 128 \

--- a/source/step-up-initiate/deploy-awscli.sh
+++ b/source/step-up-initiate/deploy-awscli.sh
@@ -82,7 +82,7 @@ if [ $? -ne 0 ]; then
         --region ${AWS_REGION} \
         --function-name ${module_name} \
         --zip-file fileb://"${module_zip_path}" \
-        --runtime nodejs12.x \
+        --runtime nodejs16.x \
         --tracing-config Mode=PassThrough \
         --timeout 30 \
         --memory-size 128 \


### PR DESCRIPTION
This PR provides a fix for the "Stepup Auth" view, which includes two buttons:
* Invoke Transfer API
* Invoke Info API

With the current code from `main`, it would throw errors, e.g. 
```
SyntaxError: Unexpected token '?'","stack":["Runtime.UserCodeSyntaxError: SyntaxError: Unexpected token '?'","    at _loadUserApp (/var/runtime/UserFunction.js:98:13)"," [....]
```
A full log of the failing lambda container can be found [here](https://gist.github.com/steffyP/4f0557f4f15b4072cf688f61a4227378).

I updated the lambda's to use node-js runtime 16.x (prior it was using 12.x).

The sample now runs on my machine, without errors, the API is invoked and returns expected results:

![Screenshot 2023-05-15 at 14 07 13](https://github.com/aws-samples/step-up-auth/assets/5726672/631b8e0b-15a6-4af5-87f0-4b9a13671495)

