### PR TITLE
fix: update LocalStack license requirement and standardize setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ deploy:
 ## Start LocalStack in detached mode
 start:
 		@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-		EXTRA_CORS_ALLOWED_ORIGINS=* PROVIDER_OVERRIDE_LAMBDA=asf LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+		EXTRA_CORS_ALLOWED_ORIGINS=* LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
 
 ## Stop the Running LocalStack container
 stop:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ deploy:
 
 ## Start LocalStack in detached mode
 start:
-		EXTRA_CORS_ALLOWED_ORIGINS=* PROVIDER_OVERRIDE_LAMBDA=asf localstack start -d
+		@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+		EXTRA_CORS_ALLOWED_ORIGINS=* PROVIDER_OVERRIDE_LAMBDA=asf LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
 
 ## Stop the Running LocalStack container
 stop:

--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ We are using the following AWS services and their features to build our infrastr
 
 ## Prerequisites
 
-- LocalStack Pro
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [LocalSurf](https://docs.localstack.cloud/user-guide/tools/localsurf/) to repoint AWS service calls to LocalStack.
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the `awslocal` wrapper.
 - [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the `cdklocal` wrapper.
-- [NodeJS v18.0.0](https://nodejs.org/en/download/) with `npm` package manager.
+- [Node.js](https://nodejs.org/en/download/) with `npm` package manager.
 
-Start LocalStack Pro with the appropriate configuration to enable the S3 website to send requests to the container APIs:
+## Start LocalStack
+
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```bash
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
-```
-Then run:
-
-```bash
-EXTRA_CORS_ALLOWED_ORIGINS=* localstack start -d
+make start
+make ready
 ```
 
 The `EXTRA_CORS_ALLOWED_ORIGINS` configuration variable allows our website to send requests through the Amplify Web Application to the privileged API to enable us to demonstrate step-up authentication.


### PR DESCRIPTION
## Summary

- Add auth guard to Makefile start target (keeps EXTRA_CORS_ALLOWED_ORIGINS=*)
- Replace LocalStack Pro with LocalStack; add license bullet; update start section in README
